### PR TITLE
Fix mustache render template parameters

### DIFF
--- a/newman/newman.js
+++ b/newman/newman.js
@@ -22,6 +22,7 @@ module.exports = function(RED) {
     this.msgContext = new mustache.Context(msg, parent);
     this.nodeContext = nodeContext;
     this.escapeStrings = escapeStrings;
+    return { msg };
   }
 
   function NewmanNode(config) {


### PR DESCRIPTION
Fix mustache render to allow us to use msg parameters.

```
....
  "reporter": { 
    "html": { 
    "export": "/home/nodejs/src/newman/{{msg._msgid}}-newman-report.html"
    },
....
```